### PR TITLE
Updates for new version of factory bot

### DIFF
--- a/factories.rb
+++ b/factories.rb
@@ -1,23 +1,23 @@
 FactoryBot.define do
   # factory blueprint for children
   factory :child do
-    first_name "Alex"
-    last_name "Heimann"
-    active true
+    first_name { "Alex" }
+    last_name { "Heimann" }
+    active { true }
   end
 
   # factory blueprint for tasks
   factory :task do
-    name "Wash dishes"
-    points 1
-    active true
+    name { "Wash dishes" }
+    points { 1 }
+    active { true }
   end
 
   # factory blueprint for chores
   factory :chore do
     association :child
     association :task
-    due_on 1.day.from_now.to_date
-    completed false
+    due_on { 1.day.from_now.to_date }
+    completed { false }
   end
 end


### PR DESCRIPTION
Factory bot's breaking changes mean that if students do not specify and older version in their Gemfile then the original facotry file will crash. This pr should fix this issue by making the factories compatable with the latest spec.